### PR TITLE
Deploy

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -3,17 +3,18 @@ default: &default
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: <%= ENV['POSTGRES_USER'] %>
-  password: <%= ENV['POSTGRES_PASSWORD'] %>
   host: <%= ENV['POSTGRES_HOST'] %>
   port: <%= ENV['POSTGRES_PORT'] %>
 
 development:
   <<: *default
   database: <%= ENV['POSTGRES_DB'] %>_development
+  password: <%= ENV['POSTGRES_PASSWORD'] %>
 
 test:
   <<: *default
   database: <%= ENV['POSTGRES_DB'] %>_test
+  password: <%= ENV['POSTGRES_PASSWORD'] %>
 
 production:
   <<: *default


### PR DESCRIPTION
本番ではログインユーザー名とデータベースのユーザー名が同じなのでident認証でDBにログインできるため、database.ymlのpassword設定はdevelopmentとtestだけに適用し、productionからは削除しました。